### PR TITLE
Add and include session and instance in user_agent

### DIFF
--- a/systemimage/config.py
+++ b/systemimage/config.py
@@ -28,14 +28,15 @@ from configparser import ConfigParser
 from contextlib import ExitStack
 from pathlib import Path
 from systemimage.bag import Bag
+from systemimage.deviceStats import DeviceStats
 from systemimage.helpers import (
     NO_PORT, as_loglevel, as_object, as_port, as_stripped, as_timedelta,
     makedirs, temporary_directory)
 
-
 SECTIONS = ('service', 'system', 'gpg', 'updater', 'hooks', 'dbus')
 USER_AGENT = ('Ubuntu System Image Upgrade Client: '
-              'device={0.device};channel={0.channel};build={0.build_number}')
+              'device={0.device};channel={0.channel};build={0.build_number}'
+              'session={0.session};instance={0.instance}')
 
 
 def expand_path(path):
@@ -90,6 +91,7 @@ class Configuration:
             self.load(directory)
         self._calculate_http_bases()
         self._resources = ExitStack()
+        self._stats = DeviceStats()
         atexit.register(self._resources.close)
 
     def _set_defaults(self):
@@ -285,6 +287,14 @@ class Configuration:
                 temporary_directory(prefix='system-image-',
                                     dir=self.system.tempdir))
         return self._tempdir
+
+    @property
+    def session(self):
+        return self._stats.getSessionId()
+
+    @property
+    def instance(self):
+        return self._stats.getInstanceId()
 
     @property
     def user_agent(self):

--- a/systemimage/deviceStats.py
+++ b/systemimage/deviceStats.py
@@ -1,0 +1,53 @@
+# Author Marius Gripsgard <mariogrip@ubports.com>
+
+import hashlib, os, subprocess, random, string
+
+# Get the device serial number
+def getSerial():
+    return subprocess.check_output(["getprop", "ro.serialno"])
+
+# Hash the serial number
+def hashSerial(serial):
+    md5 = hashlib.md5()
+    print(getSerial())
+    md5.update(getSerial())
+    return md5.hexdigest()
+
+# retrun hashed the serial number
+def getHashedSerial():
+    return hashSerial(getSerial())
+
+# Only return the first half of the hash, this way it's impossible to reverse
+def splitHash(sHash):
+    first = sHash[:len(sHash)//2]
+    return first
+
+def getHashedAndSplitedSerial():
+    return splitHash(getHashedSerial())
+
+
+class DeviceStats(object):
+    """docstring for DeviceStats."""
+    def __init__(self):
+        self.sessionId = None
+        self.instanceId = None
+        self.createSessionIdIfNull()
+        self.createInstanceIdIfNull()
+
+    def createSessionIdIfNull(self):
+        if not self.sessionId:
+            self.sessionId = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
+
+    def createInstanceIdIfNull(self):
+        if not self.instanceId:
+            self.instanceId = getHashedAndSplitedSerial()
+
+    # Session id is generated on each boot
+    def getSessionId(self):
+        self.createSessionIdIfNull()
+        return self.sessionId
+
+    # instance id is generated on first boot
+    def getInstanceId(self):
+        self.createInstanceIdIfNull()
+        return self.instanceId


### PR DESCRIPTION
This adds and includes session and instance in user_agent, this way we
can make and calculate better device stats

sessionId is a random id that is created on boot, this way we can
calculate how often the devices reboot and with this we can calculate
the stability of our builds.

instanceId is hashed and splitted in half android/device serial number,
this number is not in any way traceable since it's both hashed an
splitted in half, this way it's impossible to reverse. With
this id we can calculate how many devices is using ubports, this can also
help see how many new users, and also see how many users we loose