### PR TITLE
Bugfix/fix loop for conf.d

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-system-image (3.2+ubportsubuntu1) UNRELEASED; urgency=medium
-
-  * Fix endless loop for /etc/system-image/conf.d in system-image-dbus
-
- -- Andreas Pokorny <andreas.pokorny@gmail.com>  Sat, 15 Sep 2018 12:58:11 +0200
-
 system-image (3.2+ubports) xenial; urgency=medium
 
   * Imported to UBports

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system-image (3.2+ubportsubuntu1) UNRELEASED; urgency=medium
+
+  * Fix endless loop for /etc/system-image/conf.d in system-image-dbus
+
+ -- Andreas Pokorny <andreas.pokorny@gmail.com>  Sat, 15 Sep 2018 12:58:11 +0200
+
 system-image (3.2+ubports) xenial; urgency=medium
 
   * Imported to UBports

--- a/debian/rules
+++ b/debian/rules
@@ -47,6 +47,7 @@ override_dh_install:
 	dh_install -p system-image-dbus \
 		   systemimage/data/com.canonical.SystemImage.conf \
 		   etc/dbus-1/system.d
+	dh_installdirs etc/system-image/conf.d
 
 override_dh_installchangelogs:
 	dh_installchangelogs -k NEWS.rst

--- a/debian/rules
+++ b/debian/rules
@@ -47,7 +47,7 @@ override_dh_install:
 	dh_install -p system-image-dbus \
 		   systemimage/data/com.canonical.SystemImage.conf \
 		   etc/dbus-1/system.d
-	dh_installdirs etc/system-image/conf.d
+	dh_installdirs -p system-image-common etc/system-image/conf.d
 
 override_dh_installchangelogs:
 	dh_installchangelogs -k NEWS.rst


### PR DESCRIPTION
Whenever the system-image-dbus script runs it tries to open conf.d to find all files there. On error it retries instead of giving up. Alternatively we could make the code be less stubborn. This proposal adds an empty directoy to system-image-common