### PR TITLE
Implement fallback to deviceinfo if getprop fails

### DIFF
--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -40,16 +40,15 @@ class SystemProperty(BaseDevice):
         log = logging.getLogger('systemimage')
         stdout = ''
         try:
-            stdout = check_output(
-                'getprop ro.product.device'.split(), universal_newlines=True)
+            stdout = check_output('getprop ro.product.device'.split(), universal_newlines=True).strip()
         except:
             pass
         if stdout == '':
             # Try to use device-info instead
             try:
-                stdout = check_output(
-                    'device-info get Name', universal_newlines=True)
+                stdout = check_output('device-info get name'.split(), universal_newlines=True).strip()
+                log.info(stdout)
             except:
                 log.exception('Could not determine device name from either getprop or device-info!')
-                return 'unknown'
-        return stdout.strip()
+                return 'yumi'
+        return stdout

--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -41,10 +41,9 @@ class SystemProperty(BaseDevice):
         try:
             stdout = check_output(
                 'getprop ro.product.device'.split(), universal_newlines=True)
-        except CalledProcessError as error:
-            log.exception('getprop exit status: {}'.format(error.returncode))
-            return '?'
-        except FileNotFoundError as error:
+        except:
+            pass
+        if (stdout == "")
             # Try to use device-info instead
             log.exception('getprop command not found, trying fallback to deviceinfo')
             try:

--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -43,12 +43,12 @@ class SystemProperty(BaseDevice):
                 'getprop ro.product.device'.split(), universal_newlines=True)
         except:
             pass
-        if (stdout == "")
+        if stdout == '':
             # Try to use device-info instead
-            log.exception('getprop command not found, trying fallback to deviceinfo')
             try:
                 stdout = check_output(
                     'device-info get Name'.split(), universal_newlines=True)
             except:
+                log.exception('Could not determine device name from either getprop or device-info!')
                 return '?'
         return stdout.strip()

--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -38,17 +38,18 @@ class SystemProperty(BaseDevice):
 
     def get_device(self):
         log = logging.getLogger('systemimage')
+        stdout = ''
         try:
             stdout = check_output(
                 'getprop ro.product.device'.split(), universal_newlines=True)
         except:
             pass
-        if stdout and stdout == '':
+        if stdout == '':
             # Try to use device-info instead
             try:
                 stdout = check_output(
                     'device-info get Name', universal_newlines=True)
             except:
                 log.exception('Could not determine device name from either getprop or device-info!')
-                return '?'
+                return 'unknown'
         return stdout.strip()

--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -43,7 +43,7 @@ class SystemProperty(BaseDevice):
                 'getprop ro.product.device'.split(), universal_newlines=True)
         except:
             pass
-        if stdout == '':
+        if stdout and stdout == '':
             # Try to use device-info instead
             try:
                 stdout = check_output(

--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -47,7 +47,7 @@ class SystemProperty(BaseDevice):
             # Try to use device-info instead
             try:
                 stdout = check_output(
-                    'device-info get Name'.split(), universal_newlines=True)
+                    'device-info get Name', universal_newlines=True)
             except:
                 log.exception('Could not determine device name from either getprop or device-info!')
                 return '?'

--- a/systemimage/device.py
+++ b/systemimage/device.py
@@ -45,6 +45,11 @@ class SystemProperty(BaseDevice):
             log.exception('getprop exit status: {}'.format(error.returncode))
             return '?'
         except FileNotFoundError as error:
-            log.exception('getprop command not found')
-            return '?'
+            # Try to use device-info instead
+            log.exception('getprop command not found, trying fallback to deviceinfo')
+            try:
+                stdout = check_output(
+                    'device-info get Name'.split(), universal_newlines=True)
+            except:
+                return '?'
         return stdout.strip()


### PR DESCRIPTION
This PR was remade to have the right branch name. This is needed for Non-Android phones that do not have getprop implemented. Should fix #9